### PR TITLE
Fix loading row overflow on mobile

### DIFF
--- a/frontend/components/proposalRowLoading.tsx
+++ b/frontend/components/proposalRowLoading.tsx
@@ -6,7 +6,7 @@ export const ProposalRowLoading = ({ count = 5 }: { count: number }) => {
         <div className="rounded-md transition-all shadow-sm bg-white p-3 md:p-7 flex items-center justify-between border border-gray-200 animate-pulse">
           <div className="flex justify-center items-center text-gray-800">
             <div className="h-2.5 bg-gray-200 rounded-full dark:bg-gray-200 w-20 mr-12"></div>
-            <div className="h-2.5 bg-gray-200 rounded-full dark:bg-gray-200 w-96"></div>
+            <div className="h-2.5 bg-gray-200 rounded-full dark:bg-gray-200 w-36 sm:w-96 md:w-[500px]"></div>
           </div>
           <div className="space-x-0 md:space-x-2 space-y-2 md:space-y-0">
             <div className="h-2.5 bg-gray-200 rounded-full dark:bg-gray-200 w-12"></div>


### PR DESCRIPTION
### Before
When the loading skeletons would flash, while the page was loading, it would overflow.
<img src="https://user-images.githubusercontent.com/26611339/206884098-3e769099-080e-4d6b-81e2-19c5bc3ceef8.jpeg" width="250">

### After
Updated some breakpoints. Fwiw, with Tailwind, i love adding the [`xs` breakpoint](https://tailwindcss.com/docs/screens#adding-smaller-breakpoints) to be able to tweak stuff on mobile more easily.
![ezgif com-gif-maker (13)](https://user-images.githubusercontent.com/26611339/206884104-05a2351d-dafe-474d-8ff7-f33520099e67.gif)
